### PR TITLE
add kubero to platform service alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ List of open-source alternatives to everyday SaaS products.
 [Dokku](https://github.com/dokku/dokku)|[dokku.com](https://dokku.com/)|<a href=https://github.com/dokku/dokku><img src="https://img.shields.io/github/stars/dokku/dokku?style=flat" width=100/></a>
 [CapRover](https://github.com/caprover/caprover)|[caprover.com](https://caprover.com/)|<a href=https://github.com/caprover/caprover><img src="https://img.shields.io/github/stars/caprover/caprover?style=flat" width=100/></a>
 [Coolify](https://github.com/coollabsio/coolify)|[coolify.io](https://coolify.io/)|<a href=https://github.com/coollabsio/coolify><img src="https://img.shields.io/github/stars/coollabsio/coolify?style=flat" width=100/></a>
+[Kubero](https://github.com/kubero-dev/kubero)|[kubero.dev](https://www.kubero.dev/)|<a href=https://github.com/kubero-dev/kubero><img src="https://img.shields.io/github/stars/kubero-dev/kubero?style=flat" width=100/></a>
 
 ### Unified Communication Platform & Telephony API (Twilio alternatives):
 |Company|Website|GitHub stars|


### PR DESCRIPTION
Added my own project [Kubero](https://github.com/kubero-dev/kubero). A young competitor in the PaaS Sector. 