### PR TITLE
Add tiddlywiki and TidGi

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ List of open-source alternatives to everyday SaaS products.
 [Umami](https://github.com/umami-software/umami)|[umami.is](https://umami.is/)|<a href=https://github.com/umami-software/umami><img src="https://img.shields.io/github/stars/umami-software/umami?style=flat" width=100/></a>
 [Plausible](https://github.com/plausible/analytics)|[plausible.io](https://plausible.io/)|<a href=https://github.com/plausible/analytics><img src="https://img.shields.io/github/stars/plausible/analytics?style=flat" width=100/></a>
 
-### Note-taking/ Knowledge management (Evernote alternatives):
+### Note-taking/ Knowledge management (Evernote/Obsidian alternatives):
 |Company|Website|GitHub stars|
 |:-------|:------|:----------|
 [Joplin](https://github.com/laurent22/joplin)|[joplinapp.org](https://joplinapp.org/)|<a href=https://github.com/laurent22/joplin><img src="https://img.shields.io/github/stars/laurent22/joplin?style=flat" width=100/></a>
 [Logseq](https://github.com/logseq/logseq)|[logseq.com](https://logseq.com/)|<a href=https://github.com/logseq/logseq><img src="https://img.shields.io/github/stars/logseq/logseq?style=flat" width=100/></a>
 [SiYuan](https://github.com/siyuan-note/siyuan)|[b3log.org/siyuan/en](https://b3log.org/siyuan/en/)|<a href=https://github.com/siyuan-note/siyuan><img src="https://img.shields.io/github/stars/siyuan-note/siyuan?style=flat" width=100/></a>
+[TiddlyWiki5](https://github.com/Jermolene/TiddlyWiki5)|[tiddlywiki.com](https://tiddlywiki.com/)|<a href=https://github.com/Jermolene/TiddlyWiki5><img src="https://img.shields.io/github/stars/Jermolene/TiddlyWiki5?style=flat" width=100/></a>
 [Notesnook](https://github.com/streetwriters/notesnook)|[notesnook.com](https://notesnook.com/)|<a href=https://github.com/streetwriters/notesnook><img src="https://img.shields.io/github/stars/streetwriters/notesnook?style=flat" width=100/></a>
+[tiddly-gittly](https://github.com/tiddly-gittly)|[TidGi](https://github.com/tiddly-gittly/TidGi-Desktop)|<a href=https://github.com/tiddly-gittly/TidGi-Desktop><img src="https://img.shields.io/github/stars/tiddly-gittly/TidGi-Desktop?style=flat" width=100/></a>
 
 ### Company blogs/ newsletters (WordPress alternatives):
 |Company|Website|GitHub stars|


### PR DESCRIPTION
Tiddlywiki is a web-based note OS that can run multiple plugins (but can be used by end user directly).

TidGi is a app developed using this OS, which preinstall many plugin developed by me.